### PR TITLE
秘話の時は立ち絵表示を更新しない

### DIFF
--- a/src/app/class/chat-tab.ts
+++ b/src/app/class/chat-tab.ts
@@ -94,7 +94,8 @@ export class ChatTab extends ObjectNode implements InnerXml {
       }
       if (message[key] == null || message[key] === '') continue;
 //entyu
-      if (key === 'imagePos' && !(message['to'] != null && message['to'] !== '')) {
+      if (key === 'imagePos') {
+        if (message['to'] != null && message['to'] !== '') { continue; }
         this.pos_num = message[key];
         if( 0 <= this.pos_num && this.pos_num < this.imageIdentifier.length ){
            let oldpos = this.getImageCharactorPos(message['name']);

--- a/src/app/class/chat-tab.ts
+++ b/src/app/class/chat-tab.ts
@@ -94,7 +94,7 @@ export class ChatTab extends ObjectNode implements InnerXml {
       }
       if (message[key] == null || message[key] === '') continue;
 //entyu
-      if (key === 'imagePos') {
+      if (key === 'imagePos' && !(message['to'] != null && message['to'] !== '')) {
         this.pos_num = message[key];
         if( 0 <= this.pos_num && this.pos_num < this.imageIdentifier.length ){
            let oldpos = this.getImageCharactorPos(message['name']);

--- a/src/app/class/chat-tab.ts
+++ b/src/app/class/chat-tab.ts
@@ -95,7 +95,7 @@ export class ChatTab extends ObjectNode implements InnerXml {
       if (message[key] == null || message[key] === '') continue;
 //entyu
       if (key === 'imagePos') {
-        if (message['to'] != null && message['to'] !== '') { continue; }
+        if (message['to'] != null && message['to'] !== '') { continue; } // 秘話時に立ち絵の更新をかけない
         this.pos_num = message[key];
         if( 0 <= this.pos_num && this.pos_num < this.imageIdentifier.length ){
            let oldpos = this.getImageCharactorPos(message['name']);


### PR DESCRIPTION
### 目的

秘話の際に立ち絵表示を更新しないようにする  
これは、シノビガミ等、秘密が重要になるTRPGで必要な機能となります  
（現在の仕様では、秘話で「何か」を話していることが分かってしまう）

簡単なPRではありますが、ご確認をお願いいたします。