### PR TITLE
入力履歴をCtrl+上下で辿れる機能を追加

### DIFF
--- a/src/app/component/chat-input/chat-input.component.html
+++ b/src/app/component/chat-input/chat-input.component.html
@@ -80,6 +80,7 @@
       <form>
         <textarea class="chat-input" placeholder="Enterで送信  Shift+Enterで改行" [(ngModel)]="text"
           [ngModelOptions]="{standalone: true}" (input)="onInput()" (keydown.enter)="sendChat($event)"
+          (keydown.control.arrowup)="moveHistory($event, -1)" (keydown.control.arrowdown)="moveHistory($event, 1)"
           #textArea></textarea>
         <button type="submit" (click)="sendChat(null)">SEND</button>
       </form>

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -342,11 +342,18 @@ export class ChatInputComponent implements OnInit, OnDestroy {
       this.currentHistoryIndex = this.currentHistoryIndex + direction;
     }
 
+    let histText: string;
     if (this.currentHistoryIndex < 0) {
-      this.text = '';
+      histText = '';
     } else {
-      this.text = this.history[this.currentHistoryIndex];
+      histText = this.history[this.currentHistoryIndex];
     }
+
+    this.text = histText;
+    this.previousWritingLength = this.text.length;
+    let textArea: HTMLTextAreaElement = this.textAreaElementRef.nativeElement;
+    textArea.value = histText;
+    this.calcFitHeight();
   }
 
   sendChat(event: KeyboardEvent) {

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -326,6 +326,29 @@ export class ChatInputComponent implements OnInit, OnDestroy {
     this.calcFitHeight();
   }
 
+
+  private history: string[] = new Array();
+  private currentHistoryIndex: number = -1;
+  private static MAX_HISTORY_NUM = 1000;
+
+  moveHistory(event: KeyboardEvent, direction: number) {
+    if (event) event.preventDefault();
+
+    if (direction < 0 && this.currentHistoryIndex < 0) {
+      this.currentHistoryIndex = this.history.length - 1;
+    } else if (direction > 0 && this.currentHistoryIndex >= this.history.length - 1) {
+      this.currentHistoryIndex = -1;
+    } else {
+      this.currentHistoryIndex = this.currentHistoryIndex + direction;
+    }
+
+    if (this.currentHistoryIndex < 0) {
+      this.text = '';
+    } else {
+      this.text = this.history[this.currentHistoryIndex];
+    }
+  }
+
   sendChat(event: KeyboardEvent) {
     if (event) event.preventDefault();
 
@@ -337,6 +360,13 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 //    console.log('円柱TEST event: KeyboardEvent '+this.sendFrom + '  ' + this.tachieNum);
 //    console.log('円柱TEST event:' + this.selectChatColor);
     
+
+    if (this.history.length >= ChatInputComponent.MAX_HISTORY_NUM) {
+      this.history.shift();
+    }
+    this.history.push(this.text);
+    this.currentHistoryIndex = -1;
+
     this.chat.emit({ text: this.text, gameType: this.gameType, sendFrom: this.sendFrom
     , sendTo: this.sendTo , tachieNum : this.tachieNum ,messColor : this.selectChatColor });
 


### PR DESCRIPTION
## 概要
チャット入力欄にて「Ctrl+上下キー」で入力履歴を辿れる機能を実装しました。
どどんとふに存在した同等の機能を模したものです。

## 仕様
- 入力欄でCtrl+上キーを押すことで自身の直近の発言内容が、Ctrl+下キーを押すことで自身の履歴の先頭の発言内容が入力欄に入る
- そこからさらにCtrl+上下キーで履歴を辿れる
- 履歴を編集してから発言前に履歴を移動した場合、編集した分は失われる（戻ったときは再び履歴にあるままの内容が表示される）

## 要検討
現在は履歴の移動がループする仕様ですが、履歴の端ではそれ以上移動しないようにする案もあります