### PR TITLE
一部候補が多くなり得るプルダウンを、キーボードで選択できるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^11.0.7",
         "@angular/platform-browser-dynamic": "^11.0.7",
         "@angular/router": "^11.0.7",
+        "@ng-select/ng-select": "^6.1.0",
         "autolinker": "^3.14.2",
         "bcdice": "^3.0.0",
         "crypto-js": "^3.1.9-1",
@@ -1789,6 +1790,23 @@
         "loader-utils": "^2.0.0",
         "merge-source-map": "^1.1.0",
         "schema-utils": "^2.7.0"
+      }
+    },
+    "node_modules/@ng-select/ng-select": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-6.1.0.tgz",
+      "integrity": "sha512-uro/zIjL+TRWzbrzNN9IjIusOeLfhCn9cIr5Bq3AsJyxyU7Gdj9kOD5wVrrQ0NVkaQ1BJMcWmUvmYGBXLI6cnA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6.9.0",
+        "npm": ">= 3.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=11.0.0 <12.0.0",
+        "@angular/core": ">=11.0.0 <12.0.0",
+        "@angular/forms": ">=11.0.0 <12.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -18073,6 +18091,14 @@
         "loader-utils": "^2.0.0",
         "merge-source-map": "^1.1.0",
         "schema-utils": "^2.7.0"
+      }
+    },
+    "@ng-select/ng-select": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-6.1.0.tgz",
+      "integrity": "sha512-uro/zIjL+TRWzbrzNN9IjIusOeLfhCn9cIr5Bq3AsJyxyU7Gdj9kOD5wVrrQ0NVkaQ1BJMcWmUvmYGBXLI6cnA==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "@ngtools/webpack": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser": "^11.0.7",
     "@angular/platform-browser-dynamic": "^11.0.7",
     "@angular/router": "^11.0.7",
+    "@ng-select/ng-select": "^6.1.0",
     "autolinker": "^3.14.2",
     "bcdice": "^3.0.0",
     "crypto-js": "^3.1.9-1",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, Component, NgZone, OnDestroy, ViewChild, ViewContainerRef } from '@angular/core';
+import { NgSelectConfig } from '@ng-select/ng-select';
 
 import { ChatTabList } from '@udonarium/chat-tab-list';
 import { AudioPlayer } from '@udonarium/core/file-storage/audio-player';
@@ -70,6 +71,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     private chatMessageService: ChatMessageService,
     private appConfigService: AppConfigService,
     private saveDataService: SaveDataService,
+    private ngSelectConfig: NgSelectConfig,
     private ngZone: NgZone
   ) {
 
@@ -88,6 +90,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     });
     this.appConfigService.initialize();
     this.pointerDeviceService.initialize();
+    this.ngSelectConfig.appendTo = 'body';
 
     ChatTabList.instance.initialize();
     DataSummarySetting.instance.initialize();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -39,6 +39,7 @@ import { LobbyComponent } from 'component/lobby/lobby.component';
 import { LinkyModule } from 'ngx-linky';
 import { ModalComponent } from 'component/modal/modal.component';
 import { NetworkIndicatorComponent } from 'component/network-indicator/network-indicator.component';
+import { NgSelectModule } from '@ng-select/ng-select';
 import { OverviewPanelComponent } from 'component/overview-panel/overview-panel.component';
 import { PasswordCheckComponent } from 'component/password-check/password-check.component';
 import { PeerCursorComponent } from 'component/peer-cursor/peer-cursor.component';
@@ -147,6 +148,7 @@ import { AppComponent } from './app.component';
     CommonModule,
     FormsModule,
     LinkyModule,
+    NgSelectModule,
   ],
   providers: [
     AppConfigService,

--- a/src/app/component/chat-input/chat-input.component.html
+++ b/src/app/component/chat-input/chat-input.component.html
@@ -4,18 +4,18 @@
   </div>
   <div class="table-cell" style="width:100%">
     <div>
-      <ng-select class="ud-select" style="width: 12em; font-size: 80%;" [(ngModel)]="sendFrom" [clearable]="false">
+      <ng-select class="ud-select" style="width: 12em;" [(ngModel)]="sendFrom" [clearable]="false">
         <ng-option *ngIf="!onlyCharacters" [value]="myPeer?.identifier">{{myPeer?.name}}（あなた）</ng-option>
         <ng-option *ngFor="let gameCharacter of gameCharacters" [value]="gameCharacter.identifier">{{gameCharacter.name}}
         </ng-option>
       </ng-select> ＞
-      <ng-select class="ud-select" style="width: 10em; font-size: 80%;" [(ngModel)]="sendTo" [clearable]="false">
+      <ng-select class="ud-select" style="width: 10em;" [(ngModel)]="sendTo" [clearable]="false">
         <ng-option [value]="''">全員</ng-option>
         <ng-option *ngFor="let peer of otherPeers" [value]="peer.identifier">{{peer.name}}
           <ng-container *ngIf="peer === myPeer">（あなた）</ng-container>
         </ng-option>
       </ng-select>
-      <ng-select class="ud-select" style="width: 15em; margin-left:1em;" (change)="loadDiceBot($event)" [(ngModel)]="gameType"
+      <ng-select class="ud-select" style="width: 15em; margin-left:.1em;" (change)="loadDiceBot($event)" [(ngModel)]="gameType"
         [ngModelOptions]="{standalone: true}" [clearable]="false">
         <ng-option *ngFor="let diceBotInfo of diceBotInfos" [value]="diceBotInfo.id">{{diceBotInfo.name}}</ng-option>
       </ng-select>

--- a/src/app/component/chat-input/chat-input.component.html
+++ b/src/app/component/chat-input/chat-input.component.html
@@ -4,21 +4,21 @@
   </div>
   <div class="table-cell" style="width:100%">
     <div>
-      <select style="width: 12em;" [(ngModel)]="sendFrom">
+      <select style="width: 12em; font-size: 80%;" [(ngModel)]="sendFrom">
         <option *ngIf="!onlyCharacters" value="{{myPeer?.identifier}}">{{myPeer?.name}}（あなた）</option>
         <option *ngFor="let gameCharacter of gameCharacters" value="{{gameCharacter.identifier}}">{{gameCharacter.name}}
         </option>
       </select> ＞
-      <select style="width: 10em;" [(ngModel)]="sendTo">
+      <select style="width: 10em; font-size: 80%;" [(ngModel)]="sendTo">
         <option value="">全員</option>
         <option *ngFor="let peer of otherPeers" value="{{peer.identifier}}">{{peer.name}}
           <ng-container *ngIf="peer === myPeer">（あなた）</ng-container>
         </option>
       </select>
-      <select style="width: 12em;" (change)="loadDiceBot($event.target.value)" [(ngModel)]="gameType"
-        [ngModelOptions]="{standalone: true}">
-        <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.id}}">{{diceBotInfo.name}}</option>
-      </select>
+      <ng-select class="ud-select" style="width: 15em; margin-left:1em;" (change)="loadDiceBot($event)" [(ngModel)]="gameType"
+        [ngModelOptions]="{standalone: true}" [clearable]="false">
+        <ng-option *ngFor="let diceBotInfo of diceBotInfos" [value]="diceBotInfo.id">{{diceBotInfo.name}}</ng-option>
+      </ng-select>
       <button (click)="showDicebotHelp()">?</button>
     </div>
 

--- a/src/app/component/chat-input/chat-input.component.html
+++ b/src/app/component/chat-input/chat-input.component.html
@@ -4,17 +4,17 @@
   </div>
   <div class="table-cell" style="width:100%">
     <div>
-      <select style="width: 12em; font-size: 80%;" [(ngModel)]="sendFrom">
-        <option *ngIf="!onlyCharacters" value="{{myPeer?.identifier}}">{{myPeer?.name}}（あなた）</option>
-        <option *ngFor="let gameCharacter of gameCharacters" value="{{gameCharacter.identifier}}">{{gameCharacter.name}}
-        </option>
-      </select> ＞
-      <select style="width: 10em; font-size: 80%;" [(ngModel)]="sendTo">
-        <option value="">全員</option>
-        <option *ngFor="let peer of otherPeers" value="{{peer.identifier}}">{{peer.name}}
+      <ng-select class="ud-select" style="width: 12em; font-size: 80%;" [(ngModel)]="sendFrom" [clearable]="false">
+        <ng-option *ngIf="!onlyCharacters" [value]="myPeer?.identifier">{{myPeer?.name}}（あなた）</ng-option>
+        <ng-option *ngFor="let gameCharacter of gameCharacters" [value]="gameCharacter.identifier">{{gameCharacter.name}}
+        </ng-option>
+      </ng-select> ＞
+      <ng-select class="ud-select" style="width: 10em; font-size: 80%;" [(ngModel)]="sendTo" [clearable]="false">
+        <ng-option [value]="''">全員</ng-option>
+        <ng-option *ngFor="let peer of otherPeers" [value]="peer.identifier">{{peer.name}}
           <ng-container *ngIf="peer === myPeer">（あなた）</ng-container>
-        </option>
-      </select>
+        </ng-option>
+      </ng-select>
       <ng-select class="ud-select" style="width: 15em; margin-left:1em;" (change)="loadDiceBot($event)" [(ngModel)]="gameType"
         [ngModelOptions]="{standalone: true}" [clearable]="false">
         <ng-option *ngFor="let diceBotInfo of diceBotInfos" [value]="diceBotInfo.id">{{diceBotInfo.name}}</ng-option>

--- a/src/app/component/controller-input/controller-input.component.html
+++ b/src/app/component/controller-input/controller-input.component.html
@@ -7,11 +7,11 @@
       <div class="table">
         <div class="table-cell" >
           <div>
-            <select style="width: 10em;" [(ngModel)]="sendFrom">
-              <option *ngIf="!onlyCharacters" value="{{myPeer?.identifier}}">{{myPeer?.name}}（あなた）</option>
-              <option *ngFor="let gameCharacter of gameCharacters" value="{{gameCharacter.identifier}}">{{gameCharacter.name}}
-              </option>
-            </select> 
+            <ng-select class="ud-select" style="width: 10em;" [(ngModel)]="sendFrom" [searchable]="false" [clearable]="false">
+              <ng-option *ngIf="!onlyCharacters" [value]="myPeer?.identifier">{{myPeer?.name}}（あなた）</ng-option>
+              <ng-option *ngFor="let gameCharacter of gameCharacters" [value]="gameCharacter.identifier">{{gameCharacter.name}}
+              </ng-option>
+            </ng-select> 
           </div>
           <div>
             <div class="color" (click)="setColorNum(0);"

--- a/src/app/component/controller-input/controller-input.component.html
+++ b/src/app/component/controller-input/controller-input.component.html
@@ -11,7 +11,7 @@
               <ng-option *ngIf="!onlyCharacters" [value]="myPeer?.identifier">{{myPeer?.name}}（あなた）</ng-option>
               <ng-option *ngFor="let gameCharacter of gameCharacters" [value]="gameCharacter.identifier">{{gameCharacter.name}}
               </ng-option>
-            </ng-select> 
+            </ng-select>
           </div>
           <div>
             <div class="color" (click)="setColorNum(0);"

--- a/src/app/component/dice-table-setting/dice-table-setting.component.html
+++ b/src/app/component/dice-table-setting/dice-table-setting.component.html
@@ -36,10 +36,10 @@
       </div>
     </div>
     <div>
-      <select style="width: 12em;" (change)="loadDiceBot($event.target.value)" [(ngModel)]="gameType"
-        [ngModelOptions]="{standalone: true}" [attr.disabled]="!isEditable ? '' : null" >
-        <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.id}}">{{diceBotInfo.name}}</option>
-      </select>
+      <ng-select class="ud-select" style="width: 12em;" (change)="loadDiceBot($event)" [(ngModel)]="gameType"
+      [ngModelOptions]="{standalone: true}" [attr.disabled]="!isEditable ? '' : null" [clearable]="false">
+        <ng-option *ngFor="let diceBotInfo of diceBotInfos" [value]="diceBotInfo.id">{{diceBotInfo.name}}</ng-option>
+      </ng-select>
     </div>
 
     <div *ngIf="isEdit" class="edit-info">

--- a/src/app/component/dice-table-setting/dice-table-setting.component.html
+++ b/src/app/component/dice-table-setting/dice-table-setting.component.html
@@ -37,7 +37,7 @@
     </div>
     <div>
       <ng-select class="ud-select" style="width: 12em;" (change)="loadDiceBot($event)" [(ngModel)]="gameType"
-      [ngModelOptions]="{standalone: true}" [attr.disabled]="!isEditable ? '' : null" [clearable]="false">
+        [ngModelOptions]="{standalone: true}" [attr.disabled]="!isEditable ? '' : null" [clearable]="false">
         <ng-option *ngFor="let diceBotInfo of diceBotInfos" [value]="diceBotInfo.id">{{diceBotInfo.name}}</ng-option>
       </ng-select>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,29 @@
 /* You can add global styles to this file, and also import other style files */
+
+@import "~@ng-select/ng-select/themes/default.theme.css";
+
+.ng-select.ud-select {
+  display: inline-block;
+  vertical-align: baseline;
+  font-size: 80%;
+  min-height: 20px;
+}
+
+.ng-select.ud-select .ng-select-container{
+  min-height: 20px;
+  height: 20px;
+}
+
+.ng-select.ng-select-single .ng-select-container .ng-value-container .ng-input {
+  top: auto;
+}
+
+.ng-dropdown-panel.ud-select .ng-dropdown-panel-items .ng-option {
+  font-size: 80%;
+  padding: 4px 10px;
+}
+
+.ng-dropdown-panel.ud-select  {
+  width: auto !important;
+  max-width: 550px;
+}


### PR DESCRIPTION
## 概要
一部、候補が多くなり得るプルダウンボックスについて、ng-selectを使用してテキスト入力により検索できるようにしました。
対象としたのは以下です

- 発言者の選択プルダウン
- 秘話対象の選択プルダウン
- ダイスボットの選択プルダウン

## 備考
他のプルダウンは、数の多くない規定の選択肢から1つを選ぶものであるため、既存のスタイルを崩してまで導入するメリットは薄いと判断し、今回の導入は見送りました。
また、プルダウン形式ではない（sizeを指定した）select要素についても適用は見送っています。

ng-selectのスタイルを可能な限り違和感なくカスタマイズする目的で、styles.cssでグローバルにCSS要素を定義しています。