### PR TITLE
コマのコピー時にインベントリを検索する際、コマの名前を確認していなかった問題を修正

### DIFF
--- a/src/app/class/game-character.ts
+++ b/src/app/class/game-character.ts
@@ -133,7 +133,7 @@ export class GameCharacter extends TabletopObject {
       if( character.location.name == 'graveyard' ) continue;
       
       res = character.name.match(reg);
-      if(res != null && res.length == 3) {
+      if(res != null && res.length == 3 && res[1] == objectname) {
         let numberChk = parseInt(res[2]) + 1 ;
         if( cloneNumber <= numberChk ){
           cloneNumber = numberChk


### PR DESCRIPTION
表題のとおり、cloneNumberの決定にコマ名を見ていなかった問題を修正しました。

変更前だと、例えば「キャラクターAのコマをコピーする→キャラクターBのコマをコピーする」という手順で、キャラクターBのコマの末尾の番号が3になってしまいます。