### PR TITLE
グリッドの色をカラーピッカーで任意に指定できる機能

### DIFF
--- a/src/app/component/game-table-setting/game-table-setting.component.html
+++ b/src/app/component/game-table-setting/game-table-setting.component.html
@@ -47,7 +47,7 @@
           <option value="1">ヘクス（縦揃え）</option>
           <option value="2">ヘクス（横揃え）</option>
         </select>
-        色:
+        グリッド色:
         <input type="color" [(ngModel)]="tableGridColor" name="tableGridColor"
                list="table-grid-color-list" [attr.disabled]="!isEditable ? '' : null">
         <datalist id="table-grid-color-list">

--- a/src/app/component/game-table-setting/game-table-setting.component.html
+++ b/src/app/component/game-table-setting/game-table-setting.component.html
@@ -48,10 +48,12 @@
           <option value="2">ヘクス（横揃え）</option>
         </select>
         色:
-        <select [(ngModel)]="tableGridColor" name="tableGridColor" [attr.disabled]="!isEditable ? '' : null">
-          <option value="#000000e6">黒</option>
-          <option value="#dddddde6">白</option>
-        </select>
+        <input type="color" [(ngModel)]="tableGridColor" name="tableGridColor"
+               list="table-grid-color-list" [attr.disabled]="!isEditable ? '' : null">
+        <datalist id="table-grid-color-list">
+          <option value="#000000">
+          <option value="#dddddd">
+        </datalist>
       </div>
       <div>
         背景フィルタ

--- a/src/app/component/game-table-setting/game-table-setting.component.ts
+++ b/src/app/component/game-table-setting/game-table-setting.component.ts
@@ -42,8 +42,8 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
   get tableHeight(): number { return this.selectedTable.height; }
   set tableHeight(tableHeight: number) { if (this.isEditable) this.selectedTable.height = tableHeight; }
 
-  get tableGridColor(): string { return this.selectedTable.gridColor; }
-  set tableGridColor(tableGridColor: string) { if (this.isEditable) this.selectedTable.gridColor = tableGridColor; }
+  get tableGridColor(): string { return this.selectedTable.gridColor.substring(0, 7); }
+  set tableGridColor(tableGridColor: string) { if (this.isEditable) this.selectedTable.gridColor = tableGridColor + "e6"; }
 
   get tableGridShow(): boolean { return this.tableSelecter.gridShow; }
   set tableGridShow(tableGridShow: boolean) {


### PR DESCRIPTION
## 概要
グリッドの色をカラーピッカーで指定できるようにする機能です。datalistに元の2色の候補を指定しています。

## 仕様
- カラーピッカーはアルファチャンネルを含んだ色を扱えないため、固定で `e6` のアルファチャンネルを結合してモデルに引き渡し、またカラーピッカーのvalueは `e6` を取り除いた値としています。
- チャットの文字色指定においてと同様に、Chromeおよびその派生ブラウザにおいては、カラーピッカーが画面端に近くなると表示がバグります。