### PR TITLE
カウンターリモコンのUIを左右独立にスクロールできるように変更

### DIFF
--- a/src/app/component/remote-controller/remote-controller.component.css
+++ b/src/app/component/remote-controller/remote-controller.component.css
@@ -499,8 +499,6 @@ input[type='range']::-ms-tooltip {
 }
 
 .sticky-top-left {
-  position: sticky;
-  top: 0;
   width: 20em;
   height: calc(100% - 12px);
   overflow-y: scroll;

--- a/src/app/component/remote-controller/remote-controller.component.css
+++ b/src/app/component/remote-controller/remote-controller.component.css
@@ -501,7 +501,7 @@ input[type='range']::-ms-tooltip {
 .sticky-top-left {
   flex: 1;
   max-width: 20em;
-  height: calc(100% - 12px);
+  height: calc(100% - 11px);
   overflow-y: scroll;
   background-color: rgba(240,218,189, 0.8);
   border-top:1px dotted #666;

--- a/src/app/component/remote-controller/remote-controller.component.css
+++ b/src/app/component/remote-controller/remote-controller.component.css
@@ -499,7 +499,8 @@ input[type='range']::-ms-tooltip {
 }
 
 .sticky-top-left {
-  width: 20em;
+  flex: 1;
+  max-width: 20em;
   height: calc(100% - 12px);
   overflow-y: scroll;
   background-color: rgba(240,218,189, 0.8);

--- a/src/app/component/remote-controller/remote-controller.component.css
+++ b/src/app/component/remote-controller/remote-controller.component.css
@@ -502,7 +502,7 @@ input[type='range']::-ms-tooltip {
   position: sticky;
   top: 0;
   width: 20em;
-  height: 99%;
+  height: calc(100% - 12px);
   overflow-y: scroll;
   background-color: rgba(240,218,189, 0.8);
   border-top:1px dotted #666;
@@ -512,7 +512,7 @@ input[type='range']::-ms-tooltip {
 
 .controller-right {
   flex: 1;
-  height: 99%;
+  height: 100%;
   overflow-y: scroll;
 }
 

--- a/src/app/component/remote-controller/remote-controller.component.css
+++ b/src/app/component/remote-controller/remote-controller.component.css
@@ -12,10 +12,15 @@
   height: 100%;
 }
 
+.remote-controller-wrapper {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+}
+
 .flex-container {
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 .chat-tab {
@@ -335,11 +340,6 @@ input[type='range']::-ms-tooltip {
   color: #CCC;
 }
 
-.is-sticky-top {
-  position: sticky;
-  top : 0;
-}
-
 .tab-setting {
   background-color: transparent;
   color: #444; 
@@ -499,11 +499,11 @@ input[type='range']::-ms-tooltip {
 }
 
 .sticky-top-left {
-  float: left;
   position: sticky;
-  top : 0;
+  top: 0;
   width: 20em;
-  
+  height: 99%;
+  overflow-y: scroll;
   background-color: rgba(240,218,189, 0.8);
   border-top:1px dotted #666;
   padding:5px 5px;
@@ -511,11 +511,10 @@ input[type='range']::-ms-tooltip {
 }
 
 .controller-right {
-  position: absorute;
-  margin-left: 20em;
+  flex: 1;
+  height: 99%;
+  overflow-y: scroll;
 }
-
-
 
 .tab-setting {
   background-color: transparent;

--- a/src/app/component/remote-controller/remote-controller.component.html
+++ b/src/app/component/remote-controller/remote-controller.component.html
@@ -1,4 +1,5 @@
-<div class="table sticky-top-left" >
+<div class="remote-controller-wrapper">
+<div class="sticky-top-left">
     <div class="flex-container">
       <div style="flex-grow: 0;">
         <form>
@@ -98,18 +99,18 @@
               <ng-container *ngIf="dataElm && this.dataTags.includes(dataElm.name)">
                 <ng-container [ngSwitch]="dataElm.attributes['type']">
                   <div>
-    　　　　　  　<label *ngSwitchCase="'numberResource'">
+                  <label *ngSwitchCase="'numberResource'">
                   <input name="controller" type="radio" value="{{dataElm.name + '現在値'}}" ng-control="options" (click)="remotSelect(dataElm.name,'currentValue',(dataElm.name + '現在値'))" />
                    <div>{{dataElm.name + '現在値'}}</div>
-　                </label>
+                  </label>
                   <label *ngSwitchCase="'numberResource'">
                     <input name="controller" type="radio" value="{{dataElm.name + '最大値'}}" ng-control="options" (click)="remotSelect(dataElm.name,'value',(dataElm.name + '最大値'))" />
                     <div>{{dataElm.name + '最大値'}}</div>
                   </label>
-　　　　　        <label *ngSwitchDefault>
+                  <label *ngSwitchDefault>
                     <input name="controller" type="radio" value="{{dataElm.name}}" ng-control="options" (click)="remotSelect(dataElm.name,'value',dataElm.name)" />
                     <div>{{dataElm.name}}</div>
-　                </label>
+                  </label>
                   </div>
                 </ng-container>
               </ng-container>
@@ -120,15 +121,13 @@
     </ng-container>
 </div>
 
-<div class="controller-right" >
+<div class="controller-right">
     <div *ngIf="getGameObjects(selectTab).length < 1">{{getTabTitle(selectTab)}}インベントリは空です</div>
     <div 
      *ngFor="let gameObject of getGameObjects(selectTab); trackBy: trackByGameObject"
      [ngClass]="{'box': true, 'selected': 0 }" >
       <ng-container *ngTemplateOutlet="gameObjectTags; context:{ gameObject: gameObject}"></ng-container>
     </div>
-</div>
-
 <!-- インベントリ -->
 <ng-template #gameObjectTags let-gameObject="gameObject">
   <div class="inventory-object " >
@@ -201,5 +200,6 @@
     </ng-container>
   </div>
 </ng-template>
+</div> <!-- end of .controller-right -->
 
-
+</div> <!-- end of .remote-controller-wrapper -->


### PR DESCRIPTION
## 概要
現在のUI仕様では、ウィンドウに左カラムが収まらない場合、おかしな挙動をするようになっていました。
これを防ぎつつ使いやすいUIを考えた結果、左右で独立したカラムとし、個別にスクロールできるように調整しました

## 細かい仕様
- ウィンドウ幅が広い場合の左カラムは従来どおり20em、狭い場合は左右カラムが均等になるように変形します。
- `.is-sticky-top` は使用していないようだったので削除しました
- 一部インデントに全角スペースが混じっていたので修正しています
- 左カラムの高さの `-11px` は、上下のボーダーとパディングの幅を引いたものです
- インデントの深さの修正は機能の本質でないところでの差分が大きくなるためやっていません。