### PR TITLE
インベントリからコマを探す機能を追加

### DIFF
--- a/src/app/component/game-character/game-character.component.css
+++ b/src/app/component/game-character/game-character.component.css
@@ -272,6 +272,8 @@
 
 @keyframes focused {
   0% { box-shadow: none; }
-  50% { box-shadow: 0px 0px 10px 5px #ff0; }
+  50% { box-shadow:
+          0px 0px 10px 5px #ff0,
+          inset 0px 0px 10px 5px #ff0; }
   100% { box-shadow: none; }
 }

--- a/src/app/component/game-character/game-character.component.css
+++ b/src/app/component/game-character/game-character.component.css
@@ -263,3 +263,15 @@
 .component:hover .material-icons, .component:active .material-icons {
   display: inline;
 }
+
+.component.focused {
+  animation-name: focused;
+  animation-timing-function: ease;
+  animation-duration: 1s;
+}
+
+@keyframes focused {
+  0% { box-shadow: none; }
+  50% { box-shadow: 0px 0px 10px 5px #ff0; }
+  100% { box-shadow: none; }
+}

--- a/src/app/component/game-character/game-character.component.html
+++ b/src/app/component/game-character/game-character.component.html
@@ -1,6 +1,6 @@
 <div class="component is-3d is-grab is-pointer-events-none" [style.width.px]="size * gridSize"
   [style.height.px]="size * gridSize" appMovable [movable.option]="movableOption" (movable.ondragstart)="onMove()"
-  (movable.ondragend)="onMoved()">
+  (movable.ondragend)="onMoved()" #root>
   <div class="component-content is-3d" [@bounceInOut]="'in'">
     <div class="component-content is-3d is-pointer-events-auto" appRotable [rotable.option]="rotableOption"
       (rotable.ondragstart)="onMove()" (rotable.ondragend)="onMoved()">

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -66,8 +66,8 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
   movableOption: MovableOption = {};
   rotableOption: RotableOption = {};
 
-  private highlightTimerID: number | null;
-  private unhighlightTimerID: number | null;
+  private highlightTimer: NodeJS.Timer;
+  private unhighlightTimer: NodeJS.Timer;
 
   constructor(
     private contextMenuService: ContextMenuService,
@@ -97,23 +97,23 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
 
         console.log(`recv focus event to ${this.gameCharacter.name}`);
         // アニメーション開始のタイマーが既にあってアニメーション開始前（ごくわずかな間）ならば何もしない
-        if (this.highlightTimerID != null) { return; }
+        if (this.highlightTimer != null) { return; }
 
         // アニメーション中であればアニメーションを初期化
         if (this.rootElementRef.nativeElement.classList.contains('focused')) {
-          window.clearTimeout(this.unhighlightTimerID);
+          clearTimeout(this.unhighlightTimer);
           this.rootElementRef.nativeElement.classList.remove('focused');
         }
 
         // アニメーション開始処理タイマー
-        this.highlightTimerID = window.setTimeout(() => {
-          this.highlightTimerID = null;
+        this.highlightTimer = setTimeout(() => {
+          this.highlightTimer = null;
           this.rootElementRef.nativeElement.classList.add('focused');
         }, 0);
 
         // アニメーション終了処理タイマー
-        this.unhighlightTimerID = window.setTimeout(() => {
-          this.unhighlightTimerID = null;
+        this.unhighlightTimer = setTimeout(() => {
+          this.unhighlightTimer = null;
           this.rootElementRef.nativeElement.classList.remove('focused');
         }, 1010);
       });

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -4,10 +4,12 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   HostListener,
   Input,
   OnDestroy,
   OnInit,
+  ViewChild
 } from '@angular/core';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { ObjectNode } from '@udonarium/core/synchronize-object/object-node';
@@ -49,6 +51,7 @@ import { RemoteControllerComponent } from 'component/remote-controller/remote-co
 export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() gameCharacter: GameCharacter = null;
   @Input() is3D: boolean = false;
+  @ViewChild('root') rootElementRef: ElementRef<HTMLElement>;
 
   get name(): string { return this.gameCharacter.name; }
   get size(): number { return this.adjustMinBounds(this.gameCharacter.size); }
@@ -67,7 +70,7 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
     private contextMenuService: ContextMenuService,
     private panelService: PanelService,
     private changeDetector: ChangeDetectorRef,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
   ) { }
 
   ngOnInit() {
@@ -84,6 +87,14 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
       })
       .on('UPDATE_FILE_RESOURE', -1000, event => {
         this.changeDetector.markForCheck();
+      })
+      .on('FOCUS_TO_TABLETOP_OBJECT', event => {
+        if (this.gameCharacter !== event.data) { return; }
+        console.log(`recv focus event to ${this.gameCharacter.name}`);
+        setTimeout(() => {
+          this.rootElementRef.nativeElement.classList.remove('focused');
+        }, 1010);
+        this.rootElementRef.nativeElement.classList.add('focused');
       });
     this.movableOption = {
       tabletopObject: this.gameCharacter,

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -66,6 +66,7 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
   movableOption: MovableOption = {};
   rotableOption: RotableOption = {};
 
+  private highlightTimerID: number | null;
   private unhighlightTimerID: number | null;
 
   constructor(
@@ -97,13 +98,20 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
         if (this.rootElementRef.nativeElement.classList.contains('focused')) {
           window.clearTimeout(this.unhighlightTimerID);
           this.rootElementRef.nativeElement.classList.remove('focused');
-          void this.rootElementRef.nativeElement.offsetWidth;
         }
+        // アニメーション開始のタイマーが既にあってアニメーション開始前（ごくわずかな間）ならば何もしない
+        if (this.highlightTimerID != null) { return; }
+
+        // アニメーション開始処理タイマー
+        this.highlightTimerID = window.setTimeout(() => {
+          this.highlightTimerID = null;
+          this.rootElementRef.nativeElement.classList.add('focused');
+        }, 0);
+        // アニメーション終了処理タイマー
         this.unhighlightTimerID = window.setTimeout(() => {
-          this.rootElementRef.nativeElement.classList.remove('focused');
           this.unhighlightTimerID = null;
+          this.rootElementRef.nativeElement.classList.remove('focused');
         }, 1010);
-        this.rootElementRef.nativeElement.classList.add('focused');
       });
     this.movableOption = {
       tabletopObject: this.gameCharacter,

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -66,6 +66,8 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
   movableOption: MovableOption = {};
   rotableOption: RotableOption = {};
 
+  private unhighlightTimerID: number | null;
+
   constructor(
     private contextMenuService: ContextMenuService,
     private panelService: PanelService,
@@ -88,11 +90,18 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
       .on('UPDATE_FILE_RESOURE', -1000, event => {
         this.changeDetector.markForCheck();
       })
-      .on('FOCUS_TO_TABLETOP_OBJECT', event => {
+      .on('HIGHTLIGHT_TABLETOP_OBJECT', event => {
         if (this.gameCharacter !== event.data) { return; }
         console.log(`recv focus event to ${this.gameCharacter.name}`);
-        setTimeout(() => {
+        // アニメーション中であればアニメーションを初期化
+        if (this.rootElementRef.nativeElement.classList.contains('focused')) {
+          window.clearTimeout(this.unhighlightTimerID);
           this.rootElementRef.nativeElement.classList.remove('focused');
+          void this.rootElementRef.nativeElement.offsetWidth;
+        }
+        this.unhighlightTimerID = window.setTimeout(() => {
+          this.rootElementRef.nativeElement.classList.remove('focused');
+          this.unhighlightTimerID = null;
         }, 1010);
         this.rootElementRef.nativeElement.classList.add('focused');
       });

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -94,19 +94,21 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
       .on('HIGHTLIGHT_TABLETOP_OBJECT', event => {
         if (this.gameCharacter !== event.data) { return; }
         console.log(`recv focus event to ${this.gameCharacter.name}`);
+        // アニメーション開始のタイマーが既にあってアニメーション開始前（ごくわずかな間）ならば何もしない
+        if (this.highlightTimerID != null) { return; }
+
         // アニメーション中であればアニメーションを初期化
         if (this.rootElementRef.nativeElement.classList.contains('focused')) {
           window.clearTimeout(this.unhighlightTimerID);
           this.rootElementRef.nativeElement.classList.remove('focused');
         }
-        // アニメーション開始のタイマーが既にあってアニメーション開始前（ごくわずかな間）ならば何もしない
-        if (this.highlightTimerID != null) { return; }
 
         // アニメーション開始処理タイマー
         this.highlightTimerID = window.setTimeout(() => {
           this.highlightTimerID = null;
           this.rootElementRef.nativeElement.classList.add('focused');
         }, 0);
+
         // アニメーション終了処理タイマー
         this.unhighlightTimerID = window.setTimeout(() => {
           this.unhighlightTimerID = null;

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -92,7 +92,9 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
         this.changeDetector.markForCheck();
       })
       .on('HIGHTLIGHT_TABLETOP_OBJECT', event => {
-        if (this.gameCharacter !== event.data) { return; }
+        if (this.gameCharacter.identifier !== event.data.identifier) { return; }
+        if (this.gameCharacter.location.name != "table") { return; }
+
         console.log(`recv focus event to ${this.gameCharacter.name}`);
         // アニメーション開始のタイマーが既にあってアニメーション開始前（ごくわずかな間）ならば何もしない
         if (this.highlightTimerID != null) { return; }

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -4,7 +4,7 @@
   <div *ngIf="getGameObjects(selectTab).length < 1">{{getTabTitle(selectTab)}}インベントリは空です</div>
 <!--    <ng-container *ngIf="!gameObject.hideInventory && gameObject.location.name == 'table'"> -->
   <div (contextmenu)="onContextMenu($event, gameObject)" *ngFor="let gameObject of getGameObjects(selectTab); trackBy: trackByGameObject"
-     (click)="selectGameObject(gameObject)"  (dblclick)="focusToObject(gameObject)"
+     (click)="selectGameObject(gameObject)"  (dblclick)="focusToObject($event, gameObject)"
      [ngClass]="{'box': true, 'selected': (selectedIdentifier === gameObject.identifier)}">
     <ng-container *ngTemplateOutlet="gameObjectTags; context:{ gameObject: gameObject}"></ng-container>
   </div>

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -4,7 +4,8 @@
   <div *ngIf="getGameObjects(selectTab).length < 1">{{getTabTitle(selectTab)}}インベントリは空です</div>
 <!--    <ng-container *ngIf="!gameObject.hideInventory && gameObject.location.name == 'table'"> -->
   <div (contextmenu)="onContextMenu($event, gameObject)" *ngFor="let gameObject of getGameObjects(selectTab); trackBy: trackByGameObject"
-    (click)="selectGameObject(gameObject)" [ngClass]="{'box': true, 'selected': (selectedIdentifier === gameObject.identifier)}">
+     (click)="selectGameObject(gameObject)"  (dblclick)="focusToObject(gameObject)"
+     [ngClass]="{'box': true, 'selected': (selectedIdentifier === gameObject.identifier)}">
     <ng-container *ngTemplateOutlet="gameObjectTags; context:{ gameObject: gameObject}"></ng-container>
   </div>
 
@@ -53,7 +54,7 @@
   </ng-container>
 </ng-template>
 <ng-template #gameObjectTags let-gameObject="gameObject">
-  <div class="inventory-object" >
+  <div class="inventory-object">
     <div class="object-name">{{gameObject.name}}
       <button style="font-size: 0.8em; padding: 2px 5px;" *ngIf="selectedIdentifier === gameObject.identifier" (click)="onContextMenu($event, gameObject)">
         <i class="material-icons" style="font-size: 1em;">settings</i>

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -243,6 +243,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   selectGameObject(gameObject: GameObject) {
     let aliasName: string = gameObject.aliasName;
     EventSystem.trigger('SELECT_TABLETOP_OBJECT', { identifier: gameObject.identifier, className: gameObject.aliasName });
+    EventSystem.trigger('HIGHTLIGHT_TABLETOP_OBJECT', gameObject);
   }
 
   private deleteGameObject(gameObject: GameObject) {

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -243,9 +243,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   selectGameObject(gameObject: GameObject) {
     let aliasName: string = gameObject.aliasName;
     EventSystem.trigger('SELECT_TABLETOP_OBJECT', { identifier: gameObject.identifier, className: gameObject.aliasName });
-    if (gameObject.location.name == "table") {
-      EventSystem.trigger('HIGHTLIGHT_TABLETOP_OBJECT', gameObject);
-    }
+    EventSystem.trigger('HIGHTLIGHT_TABLETOP_OBJECT', { identifier: gameObject.identifier });
   }
 
   private deleteGameObject(gameObject: GameObject) {

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -243,7 +243,9 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   selectGameObject(gameObject: GameObject) {
     let aliasName: string = gameObject.aliasName;
     EventSystem.trigger('SELECT_TABLETOP_OBJECT', { identifier: gameObject.identifier, className: gameObject.aliasName });
-    EventSystem.trigger('HIGHTLIGHT_TABLETOP_OBJECT', gameObject);
+    if (gameObject.location.name == "table") {
+      EventSystem.trigger('HIGHTLIGHT_TABLETOP_OBJECT', gameObject);
+    }
   }
 
   private deleteGameObject(gameObject: GameObject) {

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -237,7 +237,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   private focusToObject(gameObject: GameCharacter) {
     if (gameObject.location.name != "table") { return; }
-    EventSystem.trigger('FOCUS_TO_TABLETOP_OBJECT', gameObject);
+    EventSystem.trigger('FOCUS_TO_TABLETOP_COORDINATE', { x: gameObject.location.x, y: gameObject.location.y });
   }
 
   selectGameObject(gameObject: GameObject) {

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -235,6 +235,11 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   }
 
+  private focusToObject(gameObject: GameCharacter) {
+    if (gameObject.location.name != "table") { return; }
+    EventSystem.trigger('FOCUS_TO_TABLETOP_OBJECT', gameObject);
+  }
+
   selectGameObject(gameObject: GameObject) {
     let aliasName: string = gameObject.aliasName;
     EventSystem.trigger('SELECT_TABLETOP_OBJECT', { identifier: gameObject.identifier, className: gameObject.aliasName });

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -235,7 +235,9 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   }
 
-  private focusToObject(gameObject: GameCharacter) {
+  private focusToObject(e: Event, gameObject: GameCharacter) {
+    if (!(e.target instanceof HTMLElement)) { return; }
+    if (e.target.tagName.toLowerCase() == 'input') { return; }
     if (gameObject.location.name != "table") { return; }
     EventSystem.trigger('FOCUS_TO_TABLETOP_COORDINATE', { x: gameObject.location.x, y: gameObject.location.y });
   }

--- a/src/app/component/game-table/game-table.component.ts
+++ b/src/app/component/game-table/game-table.component.ts
@@ -136,9 +136,10 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
           // x軸回転
           let rotateXRad = this.viewRotateX / 180 * Math.PI;
           let rotatedMovedY = zRotatedMovedY * Math.cos(rotateXRad);
+          let rotatedMovedZ = zRotatedMovedY * Math.sin(rotateXRad);
           // 移動
           this.setTransform(
-            -rotatedMovedX - this.viewPotisonX, -rotatedMovedY - this.viewPotisonY, 0, 0, 0, 0
+            -rotatedMovedX - this.viewPotisonX, -rotatedMovedY - this.viewPotisonY, -rotatedMovedZ - this.viewPotisonZ, 0, 0, 0
           );
         }, 50);
       });

--- a/src/app/component/game-table/game-table.component.ts
+++ b/src/app/component/game-table/game-table.component.ts
@@ -116,6 +116,31 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
         this.pointerDeviceService.isDragging = false;
         let opacity: number = this.tableSelecter.gridShow ? 1.0 : 0.0;
         this.gridCanvas.nativeElement.style.opacity = opacity + '';
+      })
+      .on('FOCUS_TO_TABLETOP_OBJECT', event => {
+        setTimeout(() => {
+          console.log(`move table to focus ${event.data.name} (${event.data.location.x}, ${event.data.location.y})`);
+          this.gameTable.nativeElement.style.transition = '0.2s ease-out';
+          setTimeout(() => {
+            this.gameTable.nativeElement.style.transition = null;
+          }, 100);
+          // 座標変換
+          let centerX = this.gridCanvas.nativeElement.clientWidth / 2;
+          let centerY = this.gridCanvas.nativeElement.clientHeight / 2;
+          let movedX = event.data.location.x - centerX;
+          let movedY = event.data.location.y - centerY;
+          // z軸回転
+          let rotateZRad = this.viewRotateZ / 180 * Math.PI;
+          let rotatedMovedX = movedX * Math.cos(rotateZRad) - movedY * Math.sin(rotateZRad);
+          let zRotatedMovedY = movedX * Math.sin(rotateZRad) + movedY * Math.cos(rotateZRad);
+          // x軸回転
+          let rotateXRad = this.viewRotateX / 180 * Math.PI;
+          let rotatedMovedY = zRotatedMovedY * Math.cos(rotateXRad);
+          // 移動
+          this.setTransform(
+            -rotatedMovedX - this.viewPotisonX, -rotatedMovedY - this.viewPotisonY, 0, 0, 0, 0
+          );
+        }, 50);
       });
     this.tabletopActionService.makeDefaultTable();
     this.tabletopActionService.makeDefaultTabletopObjects();

--- a/src/app/component/game-table/game-table.component.ts
+++ b/src/app/component/game-table/game-table.component.ts
@@ -139,7 +139,7 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
           let rotatedMovedZ = zRotatedMovedY * Math.sin(rotateXRad);
           // 移動
           this.setTransform(
-            -rotatedMovedX - this.viewPotisonX, -rotatedMovedY - this.viewPotisonY, -rotatedMovedZ - this.viewPotisonZ, 0, 0, 0
+            100 - rotatedMovedX - this.viewPotisonX, -rotatedMovedY - this.viewPotisonY, -rotatedMovedZ - this.viewPotisonZ, 0, 0, 0
           );
         }, 50);
       });

--- a/src/app/component/game-table/game-table.component.ts
+++ b/src/app/component/game-table/game-table.component.ts
@@ -117,9 +117,9 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
         let opacity: number = this.tableSelecter.gridShow ? 1.0 : 0.0;
         this.gridCanvas.nativeElement.style.opacity = opacity + '';
       })
-      .on('FOCUS_TO_TABLETOP_OBJECT', event => {
+      .on('FOCUS_TO_TABLETOP_COORDINATE', event => {
         setTimeout(() => {
-          console.log(`move table to focus ${event.data.name} (${event.data.location.x}, ${event.data.location.y})`);
+          console.log(`move table to focus (${event.data.x}, ${event.data.y})`);
           this.gameTable.nativeElement.style.transition = '0.2s ease-out';
           setTimeout(() => {
             this.gameTable.nativeElement.style.transition = null;
@@ -127,8 +127,8 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
           // 座標変換
           let centerX = this.gridCanvas.nativeElement.clientWidth / 2;
           let centerY = this.gridCanvas.nativeElement.clientHeight / 2;
-          let movedX = event.data.location.x - centerX;
-          let movedY = event.data.location.y - centerY;
+          let movedX = event.data.x - centerX;
+          let movedY = event.data.y - centerY;
           // z軸回転
           let rotateZRad = this.viewRotateZ / 180 * Math.PI;
           let rotatedMovedX = movedX * Math.cos(rotateZRad) - movedY * Math.sin(rotateZRad);


### PR DESCRIPTION
## 概要
インベントリのテーブルタブにおいて、以下の2機能を追加しました
- 項目をクリックした時、テーブル上の対象のコマを光らせる処理
- 項目をダブルクリックした時、対象のコマが画面の中央付近に位置するようテーブルを動かす処理

## 仕様
- コマを光らせる処理は何度イベントが発火しても大丈夫なようにしています。
- コマを画面中央付近に位置するようテーブルを動かす処理は、以下の仕様となっています。仕様上、コマの中心ではなく左上を基準として移動しています。
  1. transformの座標系は対象要素の中央を基準とするので、要素の中心を取得し、コマの位置（左上の座標）をこの中心を原点とした座標に変換（引くだけ）
  2. Z軸を中心とした回転の座標変換
  3. X軸を中心とした回転の座標変換（コマのZ座標は0固定であることを考慮）
  4. ここまでで変換した座標が、変換しない（上から見下ろした）座標の(100,0)に来るように、transformの値を設定
    - setTransformは相対移動の関数なので、現在値を引くことで絶対座標指定としている