### PR TITLE
テキストボックスのリサイズ処理をタイマーを用いたものに変更

### DIFF
--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -353,12 +353,7 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
     this.text = histText;
     this.previousWritingLength = this.text.length;
-    if (this.calcFitHeightInterval == null) {
-      this.calcFitHeightInterval = setTimeout(() => {
-        this.calcFitHeightInterval = null;
-        this.calcFitHeight();
-      }, 0)
-    }
+    this.kickCalcFitHeight();
   }
 
   sendChat(event: KeyboardEvent) {
@@ -384,6 +379,10 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
     this.text = '';
     this.previousWritingLength = this.text.length;
+    this.kickCalcFitHeight();
+  }
+
+  kickCalcFitHeight() {
     if (this.calcFitHeightInterval == null) {
       this.calcFitHeightInterval = setTimeout(() => {
         this.calcFitHeightInterval = null;

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -240,6 +240,8 @@ export class ChatInputComponent implements OnInit, OnDestroy {
   get myPeer(): PeerCursor { return PeerCursor.myCursor; }
   get otherPeers(): PeerCursor[] { return ObjectStore.instance.getObjects(PeerCursor); }
 
+  private calcFitHeightInterval: NodeJS.Timer = null;
+
   constructor(
     private ngZone: NgZone,
     public chatMessageService: ChatMessageService,
@@ -351,9 +353,12 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
     this.text = histText;
     this.previousWritingLength = this.text.length;
-    let textArea: HTMLTextAreaElement = this.textAreaElementRef.nativeElement;
-    textArea.value = histText;
-    this.calcFitHeight();
+    if (this.calcFitHeightInterval == null) {
+      this.calcFitHeightInterval = setTimeout(() => {
+        this.calcFitHeightInterval = null;
+        this.calcFitHeight();
+      }, 0)
+    }
   }
 
   sendChat(event: KeyboardEvent) {
@@ -379,9 +384,12 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
     this.text = '';
     this.previousWritingLength = this.text.length;
-    let textArea: HTMLTextAreaElement = this.textAreaElementRef.nativeElement;
-    textArea.value = '';
-    this.calcFitHeight();
+    if (this.calcFitHeightInterval == null) {
+      this.calcFitHeightInterval = setTimeout(() => {
+        this.calcFitHeightInterval = null;
+        this.calcFitHeight();
+      }, 0)
+    }
   }
 
   calcFitHeight() {


### PR DESCRIPTION
リサイズのために双方向バインディングしているはずの変数とDOMの値を両方修正するのが直感的に分かりにくかったため。