### PR TITLE
チャット欄でCtrl+左右キーでタブを移動する機能

### DIFF
--- a/src/app/component/chat-input/chat-input.component.html
+++ b/src/app/component/chat-input/chat-input.component.html
@@ -81,6 +81,7 @@
         <textarea class="chat-input" placeholder="Enterで送信  Shift+Enterで改行  Ctrl+上下キーで履歴呼び出し" [(ngModel)]="text"
           [ngModelOptions]="{standalone: true}" (input)="onInput()" (keydown.enter)="sendChat($event)"
           (keydown.control.arrowup)="moveHistory($event, -1)" (keydown.control.arrowdown)="moveHistory($event, 1)"
+          (keydown.control.arrowleft)="tabSwitchAction($event, -1)" (keydown.control.arrowright)="tabSwitchAction($event, 1)"
           #textArea></textarea>
         <button type="submit" (click)="sendChat(null)">SEND</button>
       </form>

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -55,6 +55,8 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
   @Output() chat = new EventEmitter<{ text: string, gameType: string, sendFrom: string, sendTo: string ,tachieNum: number ,messColor: string}>();
 
+  @Output() tabSwitch = new EventEmitter<number>();
+
   get tachieNum(): number {
     let object = ObjectStore.instance.get(this.sendFrom);
     if (object instanceof GameCharacter) {
@@ -354,6 +356,11 @@ export class ChatInputComponent implements OnInit, OnDestroy {
     this.text = histText;
     this.previousWritingLength = this.text.length;
     this.kickCalcFitHeight();
+  }
+
+  tabSwitchAction(event: KeyboardEvent, direction: number) {
+    if (event) event.preventDefault();
+    this.tabSwitch.emit(direction);
   }
 
   sendChat(event: KeyboardEvent) {

--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -8,8 +8,9 @@
         </label>
       </div>
     </form>
-    <chat-input [onlyCharacters]="true" [chatTabidentifier]="chatTabidentifier" 
-    [(gameType)]="gameType" [(sendFrom)]="sendFrom" [(text)]="text" (chat)="sendChat($event)" #chatInput></chat-input>
+    <chat-input [onlyCharacters]="true" [chatTabidentifier]="chatTabidentifier"
+    [(gameType)]="gameType" [(sendFrom)]="sendFrom" [(text)]="text"
+    (chat)="sendChat($event)" (tabSwitch)="chatTabSwitchRelative($event)" #chatInput></chat-input>
     <div *ngIf="isEdit" class="edit-info"><i class="material-icons" style="vertical-align: bottom; size:0.8rem;">info_outline</i> チャットパレット編集中です</div>
   </div>
   <div *ngIf="!isEdit" style="flex-grow: 1; height: 0; min-height: 100px;">

--- a/src/app/component/chat-palette/chat-palette.component.ts
+++ b/src/app/component/chat-palette/chat-palette.component.ts
@@ -89,6 +89,22 @@ export class ChatPaletteComponent implements OnInit, OnDestroy {
     this.updatePanelTitle();
   }
 
+  chatTabSwitchRelative(direction: number) {
+    let chatTabs = this.chatMessageService.chatTabs;
+    let index = chatTabs.findIndex((elm) => elm.identifier == this.chatTabidentifier);
+    if (index < 0) { return; }
+
+    let nextIndex: number;
+    if (index == chatTabs.length - 1 && direction == 1) {
+      nextIndex = 0;
+    } else if (index == 0 && direction == -1) {
+      nextIndex = chatTabs.length - 1;
+    } else {
+      nextIndex = index + direction;
+    }
+    this.chatTabidentifier = chatTabs[nextIndex].identifier;
+  }
+
   selectPalette(line: string) {
     this.text = line;
   }

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -20,7 +20,7 @@
       <button class="tab-setting small-font" (click)="showDiceTableSetting()"><i class="material-icons small-font">settings</i>ダイス表設定</button>
     </div>
   </form>
-  <chat-input [chatTabidentifier]="chatTabidentifier" [(gameType)]="gameType" [(sendFrom)]="sendFrom"  (chat)="sendChat($event)" ></chat-input>
+  <chat-input [chatTabidentifier]="chatTabidentifier" [(gameType)]="gameType" [(sendFrom)]="sendFrom"  (chat)="sendChat($event)" (tabSwitch)="chatTabSwitchRelative($event)"></chat-input>
 </div>
 
       

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -35,6 +35,22 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
+  chatTabSwitchRelative(direction: number) {
+    let chatTabs = this.chatMessageService.chatTabs;
+    let index = chatTabs.findIndex((elm) => elm.identifier == this.chatTabidentifier);
+    if (index < 0) { return; }
+
+    let nextIndex: number;
+    if (index == chatTabs.length - 1 && direction == 1) {
+      nextIndex = 0;
+    } else if (index == 0 && direction == -1) {
+      nextIndex = chatTabs.length - 1;
+    } else {
+      nextIndex = index + direction;
+    }
+    this.chatTabidentifier = chatTabs[nextIndex].identifier;
+  }
+
   private testcount:number = 0;
 
   get chatTab(): ChatTab { return ObjectStore.instance.get<ChatTab>(this.chatTabidentifier); }


### PR DESCRIPTION
## 概要
チャット欄でCtrl+左右キーで、タブを移動する機能を作成しました。
同等の機能がどどんとふに存在したため、それを模して作成しています。

## 細かい仕様
先頭や末尾でさらに先に進む操作をした場合、巡回するようになっています
通常のチャット入力欄だけではなくチャットパレットにも同様の機能を実装しています。