### PR TITLE
UIパネルに最小化ボタンを追加

### DIFF
--- a/src/app/component/ui-panel/ui-panel.component.css
+++ b/src/app/component/ui-panel/ui-panel.component.css
@@ -67,6 +67,10 @@
   color: #CCC;
 }
 
+.title button[disabled] {
+  opacity: 0.3;
+}
+
 .pointer-events-none {
   pointer-events: none;
 }

--- a/src/app/component/ui-panel/ui-panel.component.html
+++ b/src/app/component/ui-panel/ui-panel.component.html
@@ -8,8 +8,8 @@
 
   <div class="title" #titleBar>
     <div class="title-button">
-      <button *ngIf="!isFullScreen" (click)="toggleMinimize()"><i class="material-icons" style="font-size: 14px">minimize</i></button>
-      <button *ngIf="!isMinimized" (click)="toggleFullScreen()"><i class="material-icons" style="font-size: 14px;">fullscreen</i></button>
+      <button [disabled]="isFullScreen" (click)="toggleMinimize()"><i class="material-icons" style="font-size: 14px;">minimize</i></button>
+      <button [disabled]="isMinimized" (click)="toggleFullScreen()"><i class="material-icons" style="font-size: 14px;">fullscreen</i></button>
       <button (click)="close()"><i class="material-icons" style="font-size: 14px;">close</i></button>
     </div>
     {{panelService.title}}

--- a/src/app/component/ui-panel/ui-panel.component.html
+++ b/src/app/component/ui-panel/ui-panel.component.html
@@ -1,13 +1,15 @@
 <div [@flyInOut]="'in'" [ngClass]="{'pointer-events-none': isPointerDragging}" class="draggable-panel"
   [style.left.px]="left" [style.top.px]="top" [style.width.px]="width" [style.height.px]="height"
+  [resizable.disable]="isMinimized"
   [draggable.stack]="'.draggable-panel'" appDraggable appResizable #draggablePanel
   (mouseenter)="showTachie(true)" (mouseleave)="showTachie(false)"
   >
 <!--  style = "{{backGroundSetting(0)}}"-->
 
-  <div class="title">
+  <div class="title" #titleBar>
     <div class="title-button">
-      <button (click)="toggleFullScreen()"><i class="material-icons" style="font-size: 14px;">fullscreen</i></button>
+      <button *ngIf="!isFullScreen" (click)="toggleMinimize()"><i class="material-icons" style="font-size: 14px">minimize</i></button>
+      <button *ngIf="!isMinimized" (click)="toggleFullScreen()"><i class="material-icons" style="font-size: 14px;">fullscreen</i></button>
       <button (click)="close()"><i class="material-icons" style="font-size: 14px;">close</i></button>
     </div>
     {{panelService.title}}

--- a/src/app/component/ui-panel/ui-panel.component.ts
+++ b/src/app/component/ui-panel/ui-panel.component.ts
@@ -31,6 +31,7 @@ import { ChatTachieImageComponent } from 'component/chat-tachie-img/chat-tachie-
 export class UIPanelComponent implements OnInit {
   @ViewChild('draggablePanel', { static: true }) draggablePanel: ElementRef<HTMLElement>;
   @ViewChild('scrollablePanel', { static: true }) scrollablePanel: ElementRef<HTMLDivElement>;
+  @ViewChild('titleBar', { static: true }) titleBar: ElementRef<HTMLDivElement>;
   @ViewChild('content', { read: ViewContainerRef, static: true }) content: ViewContainerRef;
 
   @Input() set title(title: string) { this.panelService.title = title; }
@@ -50,7 +51,8 @@ export class UIPanelComponent implements OnInit {
   private preWidth: number = 100;
   private preHeight: number = 100;
 
-  private isFullScreen: boolean = false;
+  isFullScreen: boolean = false;
+  isMinimized: boolean = false;
 
   get isPointerDragging(): boolean { return this.pointerDeviceService.isDragging; }
 
@@ -103,7 +105,27 @@ export class UIPanelComponent implements OnInit {
 
   }
 */  
+  toggleMinimize() {
+    if (this.isFullScreen) return;
+
+    let body  = this.scrollablePanel.nativeElement;
+    let panel = this.draggablePanel.nativeElement;
+    if (this.isMinimized) {
+      this.isMinimized = false;
+      body.style.display = null;
+      this.height = this.preHeight;
+    } else {
+      this.preHeight = panel.offsetHeight;
+
+      this.isMinimized = true;
+      body.style.display = 'none';
+      this.height = this.titleBar.nativeElement.offsetHeight;
+    }
+  }
+
   toggleFullScreen() {
+    if (this.isMinimized) return;
+
     let panel = this.draggablePanel.nativeElement;
     if (panel.offsetLeft <= 0
       && panel.offsetTop <= 0

--- a/src/app/directive/resizable.directive.ts
+++ b/src/app/directive/resizable.directive.ts
@@ -77,6 +77,7 @@ export class ResizableDirective implements AfterViewInit, OnDestroy {
   }
 
   private onResizeStart(e: MouseEvent | TouchEvent, handle: ResizeHandler) {
+    if (this.isDisable) return this.cancel();
     if ((e as MouseEvent).button === 1 || (e as MouseEvent).button === 2) return this.cancel();
     this.handleMap.forEach(h => {
       if (h !== handle) h.input.cancel();


### PR DESCRIPTION
## 概要
UIパネルに最小化ボタンを設置し、タイトルバーのみの表示にすることができるようにしました。
用途としては、カウンターリモコン等使用率が高いが画面を大きく占有するパネルに対し、都度表示し直す手間を省くことを想定しています。

##細かい仕様
- 最小化中は最大化ボタンを押すことはできず、最大化中は最小化ボタンを押すことはできないようにしています。
- 最小化中はリサイズ機能を無効にしています。 `resizable.directive.ts` には `isDisable` パラメータはあれど使用していなかったので、これを動作するように手を加えています。