### PR TITLE
コマの詳細編集画面にて下ボタンが正しく機能しておらず、ボタンを押した要素の下の要素が末尾に移動してしまう挙動を修正

### DIFF
--- a/src/app/component/game-data-element/game-data-element.component.ts
+++ b/src/app/component/game-data-element/game-data-element.component.ts
@@ -138,8 +138,8 @@ export class GameDataElementComponent implements OnInit, OnDestroy, AfterViewIni
     let parentElement = this.gameDataElement.parent;
     let index: number = parentElement.children.indexOf(this.gameDataElement);
     if (index < parentElement.children.length - 1) {
-      let nextElement = parentElement.children[index + 1];
-      parentElement.insertBefore(nextElement, this.gameDataElement.parent);
+      let nextElement = index < parentElement.children.length - 2 ? parentElement.children[index + 2] : null;
+      parentElement.insertBefore(this.gameDataElement, nextElement);
     }
   }
 


### PR DESCRIPTION
## 詳細
例えば「１２３４５６」と並んでいる要素に対して、３に対して↓を押すと、「１２４３５６」になって欲しいのに、「１２３５６４」になってしまう

参考: insertBeforeの挙動 https://developer.mozilla.org/ja/docs/Web/API/Node/insertBefore
referenceNodeがnullの場合は末尾に移動する