### PR TITLE
インベントリ一括移動機能

### DIFF
--- a/src/app/component/game-object-inventory/game-object-inventory.component.css
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.css
@@ -264,7 +264,8 @@ input[type='range']::-ms-tooltip {
   padding: 0px;
   width: 32px;
   height: 32px;
-  display: table-cell;
+  max-width: 32px;
+  max-height: 32px;
   vertical-align: top;
 }
 

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -77,7 +77,7 @@
     </div>
     <div class="object-tags-box">
       <div class="table-cell"  *ngIf="isMultiMove">
-        <input type="checkbox" [checked]="multiMoveTargets.has(gameObject)" (change)="toggleMultiMoveTarget($event, gameObject)" />
+        <input type="checkbox" [checked]="multiMoveTargets.has(gameObject.identifier)" (change)="toggleMultiMoveTarget($event, gameObject)" />
       </div>
       <div class="table-cell">
         <div class="image-box">

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -1,6 +1,7 @@
 <div class="component">
   <ng-container *ngTemplateOutlet="inventoryTab"></ng-container>
   <ng-container *ngTemplateOutlet="inventoryViewSetting"></ng-container>
+  <ng-container *ngTemplateOutlet="inventoryMultiMove"></ng-container>
   <div *ngIf="getGameObjects(selectTab).length < 1">{{getTabTitle(selectTab)}}インベントリは空です</div>
 <!--    <ng-container *ngIf="!gameObject.hideInventory && gameObject.location.name == 'table'"> -->
   <div (contextmenu)="onContextMenu($event, gameObject)" *ngFor="let gameObject of getGameObjects(selectTab); trackBy: trackByGameObject"
@@ -53,6 +54,20 @@
     </table>
   </ng-container>
 </ng-template>
+<ng-template #inventoryMultiMove>
+  <ng-container *ngIf="isMultiMove">
+    <div style="padding-top: 6px;">
+      一括移動:
+      <button class="tab-setting small-font" (click)="onMultiMoveContextMenu()"><i class="material-icons small-font">settings</i>実行</button>
+      <button class="tab-setting small-font" (click)="toggleMultiMove()"><i class="material-icons small-font">settings</i>キャンセル</button>
+    </div>
+  </ng-container>
+  <ng-container *ngIf="!isMultiMove">
+    <div style="padding-top: 6px;">
+      <button class="tab-setting small-font" (click)="toggleMultiMove()"><i class="material-icons small-font">settings</i>一括移動</button>
+    </div>
+  </ng-container>
+</ng-template>
 <ng-template #gameObjectTags let-gameObject="gameObject">
   <div class="inventory-object">
     <div class="object-name">{{gameObject.name}}
@@ -61,8 +76,13 @@
       </button>
     </div>
     <div class="object-tags-box">
-      <div class="table-cell image-box">
-        <img *ngIf="gameObject.imageFile.url" [src]="gameObject.imageFile.url | safe: 'resourceUrl'" />
+      <div class="table-cell"  *ngIf="isMultiMove">
+        <input type="checkbox" [checked]="multiMoveTargets.has(gameObject)" (change)="toggleMultiMoveTarget($event, gameObject)" />
+      </div>
+      <div class="table-cell">
+        <div class="image-box">
+          <img *ngIf="gameObject.imageFile.url" [src]="gameObject.imageFile.url | safe: 'resourceUrl'" />
+        </div>
       </div>
       <div class="table-cell">
         <div *ngIf="gameObject.rootDataElement">

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -56,8 +56,8 @@
 </ng-template>
 <ng-template #inventoryMultiMove>
   <ng-container *ngIf="isMultiMove">
-    <div style="padding-top: 6px;">
-      一括移動:
+    <div style="font-size: 0.8em;">
+      <span style="font-weight: bold">一括移動:</span>
       <button class="tab-setting small-font" (click)="allTabBoxCheck();">
         <ng-container *ngIf="existsMultiMoveSelectedInTab(); else selectAll">全解除口↓</ng-container>
         <ng-template #selectAll>全選択〆↓</ng-template>
@@ -67,7 +67,7 @@
     </div>
   </ng-container>
   <ng-container *ngIf="!isMultiMove">
-    <div style="padding-top: 6px;">
+    <div>
       <button class="tab-setting small-font" (click)="toggleMultiMove()"><i class="material-icons small-font">settings</i>一括移動</button>
     </div>
   </ng-container>

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -58,6 +58,10 @@
   <ng-container *ngIf="isMultiMove">
     <div style="padding-top: 6px;">
       一括移動:
+      <button class="tab-setting small-font" (click)="allTabBoxCheck();">
+        <ng-container *ngIf="existsMultiMoveSelectedInTab(); else selectAll">全解除口↓</ng-container>
+        <ng-template #selectAll>全選択〆↓</ng-template>
+      </button>
       <button class="tab-setting small-font" (click)="onMultiMoveContextMenu()"><i class="material-icons small-font">settings</i>実行</button>
       <button class="tab-setting small-font" (click)="toggleMultiMove()"><i class="material-icons small-font">settings</i>キャンセル</button>
     </div>

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -215,6 +215,10 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
     SoundEffect.play(PresetSound.sweep);
   }
 
+  existsMultiMoveSelectedInTab(): boolean {
+    return this.getGameObjects(this.selectTab).some(x => this.multiMoveTargets.has(x.identifier))
+  }
+
   toggleMultiMoveTarget(e: Event, gameObject: GameCharacter) {
     if (!(e.target instanceof HTMLInputElement)) { return; }
     if (e.target.checked) {
@@ -223,6 +227,14 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
       this.multiMoveTargets.delete(gameObject.identifier);
     }
     console.log([...this.multiMoveTargets]);
+  }
+
+  allTabBoxCheck() {
+    if (this.existsMultiMoveSelectedInTab()) {
+      this.getGameObjects(this.selectTab).forEach(x => this.multiMoveTargets.delete(x.identifier));
+    } else {
+      this.getGameObjects(this.selectTab).forEach(x => this.multiMoveTargets.add(x.identifier));
+    }
   }
 
   onMultiMoveContextMenu() {

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -29,7 +29,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   selectTab: string = 'table';
   selectedIdentifier: string = '';
-  multiMoveTargets: Set<GameCharacter> = new Set();
+  multiMoveTargets: Set<string> = new Set();
 
   isEdit: boolean = false;
   isMultiMove: boolean = false;
@@ -218,11 +218,11 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   toggleMultiMoveTarget(e: Event, gameObject: GameCharacter) {
     if (!(e.target instanceof HTMLInputElement)) { return; }
     if (e.target.checked) {
-      this.multiMoveTargets.add(gameObject);
+      this.multiMoveTargets.add(gameObject.identifier);
     } else {
-      this.multiMoveTargets.delete(gameObject);
+      this.multiMoveTargets.delete(gameObject.identifier);
     }
-    console.log([...this.multiMoveTargets].map(x => x.identifier));
+    console.log([...this.multiMoveTargets]);
   }
 
   onMultiMoveContextMenu() {
@@ -260,13 +260,22 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   }
 
   multiMove(location: string) {
-    for (let gameObject of this.multiMoveTargets) {
-      gameObject.setLocation(location);
+    for (const gameObjectIdentifier of this.multiMoveTargets) {
+      let gameObject = ObjectStore.instance.get(gameObjectIdentifier);
+      if (gameObject instanceof GameCharacter) {
+        gameObject.setLocation(location);
+      }
     }
   }
 
   multiDelete() {
-    let inGraveyard = new Set([...this.multiMoveTargets].filter(x => x.location.name == 'graveyard'));
+    let inGraveyard: Set<GameCharacter> = new Set();
+    for (const gameObjectIdentifier of this.multiMoveTargets) {
+      let gameObject: GameCharacter = ObjectStore.instance.get(gameObjectIdentifier);
+      if (gameObject instanceof GameCharacter && gameObject.location.name == 'graveyard') {
+        inGraveyard.add(gameObject);
+      }
+    }
     if (inGraveyard.size < 1) return;
 
     if (!confirm(`選択したもののうち墓場に存在する${inGraveyard.size}個の要素を完全に削除しますか？`)) return;

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -226,7 +226,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
     } else {
       this.multiMoveTargets.delete(gameObject.identifier);
     }
-    console.log([...this.multiMoveTargets]);
+    console.log(`multimove selected ${[...this.multiMoveTargets]}`);
   }
 
   allTabBoxCheck() {
@@ -333,6 +333,14 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   }
 
   selectGameObject(gameObject: GameObject) {
+    if (this.isMultiMove) {
+      if (this.multiMoveTargets.has(gameObject.identifier)) {
+        this.multiMoveTargets.delete(gameObject.identifier);
+      } else {
+        this.multiMoveTargets.add(gameObject.identifier);
+      }
+      console.log(`multimove selected ${[...this.multiMoveTargets]}`);
+    }
     let aliasName: string = gameObject.aliasName;
     EventSystem.trigger('SELECT_TABLETOP_OBJECT', { identifier: gameObject.identifier, className: gameObject.aliasName });
     EventSystem.trigger('HIGHTLIGHT_TABLETOP_OBJECT', { identifier: gameObject.identifier });

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -222,6 +222,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
     } else {
       this.multiMoveTargets.delete(gameObject);
     }
+    console.log([...this.multiMoveTargets].map(x => x.identifier));
   }
 
   onMultiMoveContextMenu() {
@@ -245,6 +246,15 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
         }
       });
     }
+    if (this.selectTab == 'graveyard') {
+      actions.push({
+        name: '墓場から削除', action: () => {
+          this.multiDelete();
+          this.toggleMultiMove();
+          SoundEffect.play(PresetSound.sweep);
+        }
+      })
+    }
 
     this.contextMenuService.open(position, actions, "一括移動");
   }
@@ -252,6 +262,16 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   multiMove(location: string) {
     for (let gameObject of this.multiMoveTargets) {
       gameObject.setLocation(location);
+    }
+  }
+
+  multiDelete() {
+    let inGraveyard = new Set([...this.multiMoveTargets].filter(x => x.location.name == 'graveyard'));
+    if (inGraveyard.size < 1) return;
+
+    if (!confirm(`選択したもののうち墓場に存在する${inGraveyard.size}個の要素を完全に削除しますか？`)) return;
+    for (const gameObject of inGraveyard) {
+      this.deleteGameObject(gameObject);
     }
   }
 

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -237,7 +237,7 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   private focusToObject(e: Event, gameObject: GameCharacter) {
     if (!(e.target instanceof HTMLElement)) { return; }
-    if (e.target.tagName.toLowerCase() == 'input') { return; }
+    if (new Set(["input", "button"]).has(e.target.tagName.toLowerCase())) { return; }
     if (gameObject.location.name != "table") { return; }
     EventSystem.trigger('FOCUS_TO_TABLETOP_COORDINATE', { x: gameObject.location.x, y: gameObject.location.y });
   }


### PR DESCRIPTION
インベントリ上の一括移動機能を実装しました

## 仕様
- 「一括移動」ボタンを押すとチェックボックス表示。チェックボックスは本体だけでなくインベントリの対象キャラクターのどこをクリックしてもトグルする
- 複数タブにまたがっての選択も可能
- 「実行」ボタンをクリックすると「○○へ移動」の一覧が表示され、それをクリックすることで一括移動を行なう
  - 墓場タブの場合のみ「墓場から削除」の選択肢が表示される。この場合に削除されるのは、他に選択していても墓場にあるもののみ
- 「キャンセル」をクリックすると、全ての選択が解除された上でUIが戻る（チェックボックスも非表示）

詳しくは以下のGIFを参照ください

![multimove](https://user-images.githubusercontent.com/15855742/123440684-02cfef80-d60e-11eb-8cd2-a93a35a2f479.gif)