### PR TITLE
firefoxで `white-space: pre-wrap` が指定された要素でrubyを使うと表示がおかしくなっていた不具合の修正

### DIFF
--- a/src/app/component/chat-message/chat-message.component.html
+++ b/src/app/component/chat-message/chat-message.component.html
@@ -39,7 +39,7 @@
   </div>
 </div>
 <ng-template #visible>
-  <span [innerHTML]="escapeHtmlAndRuby(chatMessage.text) | linky:{stripPrefix: false}"></span>
+  <span [innerHTML]="escapeHtmlAndRuby(chatMessage.text) | linky:{stripPrefix: false} | safe"></span>
   <button *ngIf="chatMessage.isSecret" (click)="discloseMessage()">内容を公開</button>
 </ng-template>
 <ng-template #secret>

--- a/src/app/component/chat-message/chat-message.component.ts
+++ b/src/app/component/chat-message/chat-message.component.ts
@@ -66,7 +66,7 @@ export class ChatMessageComponent implements OnInit, AfterViewInit {
     // 記入例：|永遠力暴風雪《エターナルフォースブリザード》
     // 振られる側に《スキル名》は有効：|《約束された勝利の剣》《エクスカリバー》
     let escapeText = this.escapeHtml(text);
-    return escapeText.replace(/[\|｜]([^\|｜\s]+?)《(.+?)》/g, '<ruby>$1<rt>$2</rt></ruby>').replace(/\\s/g,' ');
+    return escapeText.replace(/[\|｜]([^\|｜\s]+?)《(.+?)》/g, '<ruby style="white-space:normal;">$1<rt>$2</rt></ruby>').replace(/\\s/g,' ');
   }
 
   escapeHtml(text) {


### PR DESCRIPTION
表題の状況でルビのベーステキストが強制的に左詰めになり、特にルビテキストの方が長い場合に不自然な表示になっていたのを修正しました。
以下のスクリーンショットの1発言目が改修前を擬似的に再現したもの、2発言目が改修後のものです
![image](https://user-images.githubusercontent.com/15855742/154847569-dd3dd93f-9cab-42ea-8b71-2e29fc343df8.png)
