### PR TITLE
modal window上において、ng-selectの候補一覧が背面にまわってしまう問題の修正

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -26,4 +26,5 @@
 .ng-dropdown-panel.ud-select  {
   width: auto !important;
   max-width: 550px;
+  z-index: 2000000;
 }


### PR DESCRIPTION
modal componentに指定されているz-indexの1899999という大きな値より上の値を設定する必要があった

再現手順

- テーブル上で右クリック→テーブル設定
- 出てきたウィンドウの下部にあるダイスボット一覧のプルダウンをクリック

再現画像
![image](https://user-images.githubusercontent.com/15855742/192102134-e5211ff9-77e6-4eba-9287-1a047c7b7a14.png)
